### PR TITLE
fix: ignore special characters on server name filtering

### DIFF
--- a/src/commands/updateservers.js
+++ b/src/commands/updateservers.js
@@ -30,7 +30,7 @@ class UpdateserversCommand extends Command{
         for(let i = 65; i < 91; i++){
             const letter = String.fromCharCode(i);
             const guildDocs = await guildModel.find({
-                name: {$regex: new RegExp(`^${letter}`, 'i')},
+                name: {$regex: new RegExp(`^((?:\\W|\\d)+)?${letter}`, 'i')},
                 pending: {$ne: true},
             });
             if(!guildDocs.length) continue;


### PR DESCRIPTION
### new regex to filter server names like:

```
𓂃 🌙 Kimetsu no Yaiba : New Generation™ 🌈
🍂 Martine's house 🍂
```